### PR TITLE
Add table options

### DIFF
--- a/inst/themes/ayuntamiento-madrid.yaml
+++ b/inst/themes/ayuntamiento-madrid.yaml
@@ -54,6 +54,7 @@ themes:
     link_color: "#078083"
     header_background: "#003df6"
     table_background: "#fffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -111,6 +112,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#1d5eff"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/ayuntamiento-madrid.yaml
+++ b/inst/themes/ayuntamiento-madrid.yaml
@@ -31,6 +31,31 @@ themes:
     grid_line_type: ShortDot
     legend_color: '#20293f'
     legend_family: Gill Sans Bold
+    table_title_color: "#2b303a"
+    table_title_family: Gill Sans Bold
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Gill Sans Bold
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Gill Sans Bold
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Gill Sans Bold
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Gill Sans Bold
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#003df6"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     logo: ayuntamiento-madrid
     logo_position: right
@@ -63,6 +88,31 @@ themes:
     grid_line_type: ShortDot
     legend_color: '#ffffff'
     legend_family: Gill Sans Bold
+    table_title_color: "#ffffff"
+    table_title_family: Gill Sans Bold
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Gill Sans Bold
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Gill Sans Bold
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Gill Sans Bold
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Gill Sans Bold
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#1d5eff"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/chispa-cali.yaml
+++ b/inst/themes/chispa-cali.yaml
@@ -61,7 +61,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#fd954f"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -127,6 +128,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#fd954f"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/chispa-cali.yaml
+++ b/inst/themes/chispa-cali.yaml
@@ -39,6 +39,31 @@ themes:
     legend_color: '#444242'
     legend_family: Mukta
     legend_size: 13
+    table_title_color: "#2b303a"
+    table_title_family: Mukta
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Mukta
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Mukta
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Mukta
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Mukta
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#fd954f"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -79,6 +104,31 @@ themes:
     legend_color: '#ffffff'
     legend_family: Mukta
     legend_size: 13
+    table_title_color: "#ffffff"
+    table_title_family: Mukta
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Mukta
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Mukta
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Mukta
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Mukta
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#fd954f"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/cuestion-publica.yaml
+++ b/inst/themes/cuestion-publica.yaml
@@ -59,7 +59,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#691b50"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -123,6 +124,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#691b50"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/cuestion-publica.yaml
+++ b/inst/themes/cuestion-publica.yaml
@@ -37,6 +37,31 @@ themes:
     grid_line_type: ShortDash
     legend_color: '#2d2833'
     legend_family: Montserrat
+    table_title_color: "#2b303a"
+    table_title_family: Montserrat
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Montserrat
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Montserrat
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Montserrat
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Montserrat
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#691b50"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -75,6 +100,31 @@ themes:
     grid_line_type: Dash
     legend_color: '#ffffff'
     legend_family: Montserrat
+    table_title_color: "#ffffff"
+    table_title_family: Montserrat
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Montserrat
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Montserrat
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Montserrat
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Montserrat
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#691b50"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/datasketch.yaml
+++ b/inst/themes/datasketch.yaml
@@ -55,7 +55,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#3a3766"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -113,6 +114,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#4f63db"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/datasketch.yaml
+++ b/inst/themes/datasketch.yaml
@@ -33,6 +33,31 @@ themes:
     grid_line_type: ShortDot
     legend_color: '#222526'
     legend_family: IBM Plex Sans
+    table_title_color: "#2b303a"
+    table_title_family: IBM Plex Sans
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: IBM Plex Sans
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: IBM Plex Sans
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: IBM Plex Sans
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: IBM Plex Sans
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#3a3766"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     logo: datasketch
     logo_position: right
@@ -65,6 +90,31 @@ themes:
     legend_family: IBM Plex Sans
     grid_color: '#929298'
     grid_line_type: Solid
+    table_title_color: "#ffffff"
+    table_title_family: IBM Plex Sans
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: IBM Plex Sans
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: IBM Plex Sans
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: IBM Plex Sans
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: IBM Plex Sans
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#4f63db"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/dialogos.yaml
+++ b/inst/themes/dialogos.yaml
@@ -60,7 +60,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#0c95ba"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -125,6 +126,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#0c95ba"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/dialogos.yaml
+++ b/inst/themes/dialogos.yaml
@@ -38,6 +38,31 @@ themes:
     grid_line_type: solid
     legend_color: '#2e3b42'
     legend_family: Barlow
+    table_title_color: "#2b303a"
+    table_title_family: Barlow
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Barlow
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Barlow
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Barlow
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Barlow
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#0c95ba"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -77,6 +102,31 @@ themes:
     grid_line_type: solid
     legend_color: '#ffffff'
     legend_family: Barlow
+    table_title_color: "#ffffff"
+    table_title_family: Barlow
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Barlow
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Barlow
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Barlow
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Barlow
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#0c95ba"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/dialogos.yaml
+++ b/inst/themes/dialogos.yaml
@@ -5,7 +5,7 @@ themes:
     #plot_margin_top: 30
     logo: ''
     logo_position: right
-    logo_width: 60
+    logo_width: 100
     logo_height: 40
     branding_include: true
     palette_colors: ~
@@ -69,7 +69,7 @@ themes:
     #plot_margin_top: 30
     logo: ''
     logo_position: right
-    logo_width: 60
+    logo_width: 100
     logo_height: 40
     branding_include: true
     palette_colors: ~

--- a/inst/themes/ecuador-datos-abiertos.yaml
+++ b/inst/themes/ecuador-datos-abiertos.yaml
@@ -33,6 +33,31 @@ themes:
     grid_line_type: Dot
     legend_color: '#324142'
     legend_family: Inter Regular
+    table_title_color: "#2b303a"
+    table_title_family: Inter Regular
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Inter Regular
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Inter Regular
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Inter Regular
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Inter Regular
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#e24329"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     logo:
     logo_position: right
@@ -65,6 +90,31 @@ themes:
     legend_family: Inter Regular
     grid_color: '#464c4c'
     grid_line_type: Dot
+    table_title_color: "#ffffff"
+    table_title_family: Inter Regular
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Inter Regular
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Inter Regular
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Inter Regular
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Inter Regular
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#e24329"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/ecuador-datos-abiertos.yaml
+++ b/inst/themes/ecuador-datos-abiertos.yaml
@@ -55,7 +55,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#e24329"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -113,6 +114,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#e24329"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/hivos.yaml
+++ b/inst/themes/hivos.yaml
@@ -55,7 +55,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#d51317"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -113,6 +114,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#f0e2b0"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/hivos.yaml
+++ b/inst/themes/hivos.yaml
@@ -33,6 +33,31 @@ themes:
     grid_line_type: Dot
     legend_color: '#111111'
     legend_family: Museo Sans Rounded
+    table_title_color: "#2b303a"
+    table_title_family: Times New Roman Italic
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Times New Roman Italic
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Museo Sans Rounded
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Times New Roman Italic
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Museo Sans Rounded
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#d51317"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     logo: hivos
     logo_position: right
@@ -65,6 +90,31 @@ themes:
     legend_family: Museo Sans Rounded
     grid_color: '#dbd9d9'
     grid_line_type: Dot
+    table_title_color: "#ffffff"
+    table_title_family: Times New Roman Italic
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Times New Roman Italic
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Museo Sans Rounded
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Times New Roman Italic
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Museo Sans Rounded
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#f0e2b0"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/itpc.yaml
+++ b/inst/themes/itpc.yaml
@@ -60,7 +60,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#e7322d"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -125,6 +126,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#e7322d"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/itpc.yaml
+++ b/inst/themes/itpc.yaml
@@ -38,6 +38,31 @@ themes:
     legend_color: '#222526'
     legend_family: Lato
     tooltip_family: Lato
+    table_title_color: "#2b303a"
+    table_title_family: Source Serif Pro
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Source Serif Pro
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Source Serif Pro
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Source Serif Pro
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Source Serif Pro
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#e7322d"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -77,6 +102,31 @@ themes:
     legend_color: '#ffffff'
     legend_family: Lato
     tooltip_family: Lato
+    table_title_color: "#ffffff"
+    table_title_family: Source Serif Pro
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Source Serif Pro
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Source Serif Pro
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Source Serif Pro
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Source Serif Pro
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#e7322d"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/jamundi.yaml
+++ b/inst/themes/jamundi.yaml
@@ -31,6 +31,31 @@ themes:
     grid_line_type: ShortDot
     legend_color: '#061410'
     legend_family: Lato
+    table_title_color: "#2b303a"
+    table_title_family: Helvetica
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Helvetica
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Helvetica
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Helvetica
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Helvetica
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#78cb48"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     logo: jamundi
     logo_position: right
@@ -63,6 +88,31 @@ themes:
     grid_line_type: ShortDot
     legend_color: '#ffffff'
     legend_family: Lato
+    table_title_color: "#ffffff"
+    table_title_family: Helvetica
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Helvetica
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Helvetica
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Helvetica
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Helvetica
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#78cb48"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/jamundi.yaml
+++ b/inst/themes/jamundi.yaml
@@ -53,7 +53,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#78cb48"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -111,6 +112,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#78cb48"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/miga.yaml
+++ b/inst/themes/miga.yaml
@@ -37,6 +37,31 @@ themes:
     grid_line_type: Dot
     legend_color: '#232323'
     legend_family: PT Sans Narrow
+    table_title_color: "#2b303a"
+    table_title_family: PT Sans Narrow
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: PT Sans Narrow
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: PT Sans Narrow
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: PT Sans Narrow
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: PT Sans Narrow
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#1b7267"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -75,6 +100,31 @@ themes:
     grid_line_type: Dot
     legend_color: '#ffffff'
     legend_family: PT Sans Narrow
+    table_title_color: "#ffffff"
+    table_title_family: PT Sans Narrow
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: PT Sans Narrow
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: PT Sans Narrow
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: PT Sans Narrow
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: PT Sans Narrow
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#1b7267"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/miga.yaml
+++ b/inst/themes/miga.yaml
@@ -59,7 +59,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#1b7267"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -123,6 +124,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#1b7267"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/miga.yaml
+++ b/inst/themes/miga.yaml
@@ -5,7 +5,7 @@ themes:
     #plot_margin_top: 30
     logo: ''
     logo_position: right
-    logo_width: 70
+    logo_width: 150
     branding_include: true
     palette_colors: ~
     background_color: '#fafafa'
@@ -68,7 +68,7 @@ themes:
     #plot_margin_top: 30
     logo: ''
     logo_position: right
-    #logo_width: 70
+    logo_width: 150
     branding_include: true
     palette_colors: ~
     background_color: '#232323'

--- a/inst/themes/muy-waso.yaml
+++ b/inst/themes/muy-waso.yaml
@@ -39,6 +39,31 @@ themes:
     legend_color: '#232323'
     legend_family: Roboto Condensed
     tooltip_family: Roboto Condensed
+    table_title_color: "#2b303a"
+    table_title_family: Oswald
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Oswald
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Oswald
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Oswald
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Oswald
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#5ad0ca"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -78,6 +103,31 @@ themes:
     legend_color: '#ffffff'
     legend_family: Roboto Condensed
     tooltip_family: Roboto Condensed
+    table_title_color: "#ffffff"
+    table_title_family: Oswald
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Oswald
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Oswald
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Oswald
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Oswald
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#5ad0ca"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/muy-waso.yaml
+++ b/inst/themes/muy-waso.yaml
@@ -61,7 +61,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#5ad0ca"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -126,6 +127,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#5ad0ca"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -1,12 +1,7 @@
 themes:
   light:
-    #plot_margin_left: 50
-    #plot_margin_right: 50
-    #plot_margin_top: 30
     logo: ''
     logo_position: right
-    #logo_width: 200
-    #logo_height: 40
     branding_include: true
     palette_colors: ~
     background_color: '#fafafa'
@@ -38,10 +33,28 @@ themes:
     grid_line_type: ShortDash
     legend_color: '#2b303a'
     legend_family: Lato
+    table_title_color: "#2b303a"
+    table_title_family: Fjalla One
+    table_title_size: 30
+    table_title_weight: 700
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Lato
+    table_subtitle_size: 18
+    table_subtitle_weight: 400
+    header_text_color: "#ffffff"
+    header_text_family: Fjalla One
+    header_text_size: 22
+    header_text_weight: 700
+    cell_text_color: "#2b303a"
+    cell_text_family: Lato
+    cell_text_size: 18
+    cell_text_weight: 400
+    link_color: "#078083"
+    header_background: "#d34028"
+    zebra_stripe1: "#ffffff"
+    zebra_stripe2: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
-    #plot_margin_left: 50
-    #plot_margin_right: 50
-    #plot_margin_top: 30
     logo: ''
     logo_position: right
     logo_width: 200
@@ -76,6 +89,27 @@ themes:
     grid_line_type: ShortDash
     legend_color: '#ffffff'
     legend_family: Lato
+    table_title_color: "#2b303a"
+    table_title_family: Fjalla One
+    table_title_size: 30
+    table_title_weight: 700
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Lato
+    table_subtitle_size: 18
+    table_subtitle_weight: 400
+    header_text_color: "#ffffff"
+    header_text_family: Fjalla One
+    header_text_size: 22
+    header_text_weight: 700
+    cell_text_color: "#2b303a"
+    cell_text_family: Lato
+    cell_text_size: 18
+    cell_text_weight: 400
+    link_color: "#078083"
+    header_background: "#d34028"
+    zebra_stripe1: "#ffffff"
+    zebra_stripe2: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
 palettes:
   light:
     main:

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -55,8 +55,7 @@ themes:
     cell_text_weight: 400
     link_color: "#078083"
     header_background: "#d34028"
-    zebra_stripe1: "#ffffff"
-    zebra_stripe2: "#f6fcfa"
+    zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
     logo: ''
@@ -115,8 +114,7 @@ themes:
     cell_text_weight: 400
     link_color: "#078083"
     header_background: "#d34028"
-    zebra_stripe1: "#ffffff"
-    zebra_stripe2: "#f6fcfa"
+    zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
 palettes:
   light:

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -36,11 +36,15 @@ themes:
     table_title_color: "#2b303a"
     table_title_family: Fjalla One
     table_title_size: 30
-    table_title_weight: 700
+    table_title_weight: normal
     table_subtitle_color: "#2b303a"
     table_subtitle_family: Lato
     table_subtitle_size: 18
-    table_subtitle_weight: 400
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Lato
+    table_caption_size: 11
+    table_caption_weight: normal
     header_text_color: "#ffffff"
     header_text_family: Fjalla One
     header_text_size: 22
@@ -92,11 +96,15 @@ themes:
     table_title_color: "#2b303a"
     table_title_family: Fjalla One
     table_title_size: 30
-    table_title_weight: 700
+    table_title_weight: normal
     table_subtitle_color: "#2b303a"
     table_subtitle_family: Lato
     table_subtitle_size: 18
-    table_subtitle_weight: 400
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Lato
+    table_caption_size: 11
+    table_caption_weight: normal
     header_text_color: "#ffffff"
     header_text_family: Fjalla One
     header_text_size: 22

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -55,7 +55,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#d34028"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -116,6 +117,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#d34028"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -55,6 +55,7 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#d34028"
+    table_background: "#fffff"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -114,6 +115,7 @@ themes:
     cell_text_weight: 400
     link_color: "#69d6b6"
     header_background: "#d34028"
+    table_background: "#222526"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -109,7 +109,7 @@ themes:
     header_text_family: Fjalla One
     header_text_size: 22
     header_text_weight: 700
-    cell_text_color: "#2b303a"
+    cell_text_color: "#ffffff"
     cell_text_family: Lato
     cell_text_size: 18
     cell_text_weight: 400

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -108,11 +108,11 @@ themes:
     header_text_color: "#ffffff"
     header_text_family: Fjalla One
     header_text_size: 22
-    header_text_weight: 700
+    header_text_weight: normal
     cell_text_color: "#ffffff"
     cell_text_family: Lato
     cell_text_size: 18
-    cell_text_weight: 400
+    cell_text_weight: normal
     link_color: "#69d6b6"
     header_background: "#d34028"
     table_background: "#222526"

--- a/inst/themes/ojo-con-mi-pisto.yaml
+++ b/inst/themes/ojo-con-mi-pisto.yaml
@@ -48,11 +48,11 @@ themes:
     header_text_color: "#ffffff"
     header_text_family: Fjalla One
     header_text_size: 22
-    header_text_weight: 700
+    header_text_weight: normal
     cell_text_color: "#2b303a"
     cell_text_family: Lato
     cell_text_size: 18
-    cell_text_weight: 400
+    cell_text_weight: normal
     link_color: "#078083"
     header_background: "#d34028"
     zebra_stripe_color: "#f6fcfa"
@@ -92,15 +92,15 @@ themes:
     grid_line_type: ShortDash
     legend_color: '#ffffff'
     legend_family: Lato
-    table_title_color: "#2b303a"
+    table_title_color: "#ffffff"
     table_title_family: Fjalla One
     table_title_size: 30
     table_title_weight: normal
-    table_subtitle_color: "#2b303a"
+    table_subtitle_color: "#ffffff"
     table_subtitle_family: Lato
     table_subtitle_size: 18
     table_subtitle_weight: normal
-    table_caption_color: "#2b303a"
+    table_caption_color: "#ffffff"
     table_caption_family: Lato
     table_caption_size: 11
     table_caption_weight: normal
@@ -112,10 +112,10 @@ themes:
     cell_text_family: Lato
     cell_text_size: 18
     cell_text_weight: 400
-    link_color: "#078083"
+    link_color: "#69d6b6"
     header_background: "#d34028"
-    zebra_stripe_color: "#f6fcfa"
-    desactivated_controls: "#bbbdc0"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/ojo-publico.yaml
+++ b/inst/themes/ojo-publico.yaml
@@ -38,6 +38,31 @@ themes:
     grid_line_type: Dot
     legend_color: '#333333'
     legend_family: Nunito Sans
+    table_title_color: "#2b303a"
+    table_title_family: Nunito Sans
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Nunito Sans
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Nunito Sans
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Nunito Sans
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Nunito Sans
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#fdbc18"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -75,6 +100,31 @@ themes:
     grid_line_type: Dot
     legend_color: '#FFFFFF'
     legend_family: Nunito Sans
+    table_title_color: "#ffffff"
+    table_title_family: Nunito Sans
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Nunito Sans
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Nunito Sans
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Nunito Sans
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Nunito Sans
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#fdbc18"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/ojo-publico.yaml
+++ b/inst/themes/ojo-publico.yaml
@@ -60,7 +60,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#fdbc18"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -123,6 +124,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#fdbc18"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/palmira.yaml
+++ b/inst/themes/palmira.yaml
@@ -31,6 +31,31 @@ themes:
     grid_line_type: ShortDot
     legend_color: '#03110a'
     legend_family: Trebuchet MS
+    table_title_color: "#2b303a"
+    table_title_family: Helvetica
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Helvetica
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Trebuchet MS
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Helvetica
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Trebuchet MS
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#1ba470"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     logo: palmira
     logo_position: right
@@ -63,6 +88,31 @@ themes:
     grid_line_type: ShortDot
     legend_color: '#ffffff'
     legend_family: Trebuchet MS
+    table_title_color: "#ffffff"
+    table_title_family: Helvetica
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Helvetica
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Trebuchet MS
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Helvetica
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Trebuchet MS
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#1ba470"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/palmira.yaml
+++ b/inst/themes/palmira.yaml
@@ -53,7 +53,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#1ba470"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -111,6 +112,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#1ba470"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/poder.yaml
+++ b/inst/themes/poder.yaml
@@ -38,6 +38,31 @@ themes:
     grid_line_type: ShortDash
     legend_color: '#2d3b42'
     legend_family: Roboto Condensed
+    table_title_color: "#2b303a"
+    table_title_family: Roboto Condensed
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#2b303a"
+    table_subtitle_family: Roboto Condensed
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#2b303a"
+    table_caption_family: Roboto Condensed
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Roboto Condensed
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#2b303a"
+    cell_text_family: Roboto Condensed
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#078083"
+    header_background: "#2e64a2"
+    table_background: "#fffff"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     #plot_margin_left: 50
     #plot_margin_right: 50
@@ -77,6 +102,31 @@ themes:
     grid_line_type: ShortDash
     legend_color: '#ffffff'
     legend_family: Roboto Condensed
+    table_title_color: "#ffffff"
+    table_title_family: Roboto Condensed
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: "#ffffff"
+    table_subtitle_family: Roboto Condensed
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: "#ffffff"
+    table_caption_family: Roboto Condensed
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Roboto Condensed
+    header_text_size: 22
+    header_text_weight: normal
+    cell_text_color: "#ffffff"
+    cell_text_family: Roboto Condensed
+    cell_text_size: 18
+    cell_text_weight: normal
+    link_color: "#69d6b6"
+    header_background: "#58cdcc"
+    table_background: "#222526"
+    zebra_stripe_color: "#2e3237"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/poder.yaml
+++ b/inst/themes/poder.yaml
@@ -60,7 +60,8 @@ themes:
     cell_text_weight: normal
     link_color: "#078083"
     header_background: "#2e64a2"
-    table_background: "#fffff"
+    table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#f6fcfa"
     desactivated_controls: "#bbbdc0"
   dark:
@@ -125,6 +126,7 @@ themes:
     link_color: "#69d6b6"
     header_background: "#58cdcc"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2e3237"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/poder.yaml
+++ b/inst/themes/poder.yaml
@@ -5,7 +5,7 @@ themes:
     #plot_margin_top: 30
     logo: ''
     logo_position: right
-    logo_width: 50
+    logo_width: 150
     logo_height: 50
     branding_include: true
     palette_colors: ~
@@ -69,7 +69,7 @@ themes:
     #plot_margin_top: 30
     logo: ''
     logo_position: right
-    logo_width: 50
+    logo_width: 150
     logo_height: 50
     branding_include: true
     palette_colors: ~

--- a/inst/themes/public.yaml
+++ b/inst/themes/public.yaml
@@ -55,7 +55,7 @@ themes:
     cell_text_weight: normal
     link_color: "#287e68"
     header_background: "#385573"
-    table_background: "#fffff"
+    table_background: "#ffffff"
     zebra_stripe_color: "#fafafa"
     desactivated_controls: "#becacc"
   dark:

--- a/inst/themes/public.yaml
+++ b/inst/themes/public.yaml
@@ -102,7 +102,7 @@ themes:
     table_caption_size: 11
     table_caption_weight: normal
     header_text_color: "#ffffff"
-    header_text_family: Fjalla One
+    header_text_family: IBM Plex Sans
     header_text_size: 22
     header_text_weight: 700
     cell_text_color: '#28333f'

--- a/inst/themes/public.yaml
+++ b/inst/themes/public.yaml
@@ -55,6 +55,7 @@ themes:
     cell_text_weight: normal
     link_color: "#287e68"
     header_background: "#385573"
+    table_background: "#fffff"
     zebra_stripe_color: "#fafafa"
     desactivated_controls: "#becacc"
   dark:
@@ -111,6 +112,7 @@ themes:
     cell_text_weight: normal
     link_color: "#99e8b3"
     header_background: "#385573"
+    table_background: "#222526"
     zebra_stripe_color: "#2b3238"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/public.yaml
+++ b/inst/themes/public.yaml
@@ -33,6 +33,30 @@ themes:
     grid_line_type: Dot
     legend_color: '#28333f'
     legend_family: IBM Plex Sans
+    table_title_color: '#28333f'
+    table_title_family: IBM Plex Sans
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: '#28333f'
+    table_subtitle_family: IBM Plex Sans
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: '#28333f'
+    table_caption_family: IBM Plex Sans
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Fjalla One
+    header_text_size: 22
+    header_text_weight: 700
+    cell_text_color: '#28333f'
+    cell_text_family: IBM Plex Sans
+    cell_text_size: 18
+    cell_text_weight: 400
+    link_color: "#e59fd7"
+    header_background: "#385573"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
   dark:
     logo: datasketch
     logo_position: right
@@ -65,6 +89,30 @@ themes:
     legend_family: IBM Plex Sans
     grid_color: '#a1a0a5'
     grid_line_type: Dot
+    table_title_color: '#28333f'
+    table_title_family: IBM Plex Sans
+    table_title_size: 30
+    table_title_weight: normal
+    table_subtitle_color: '#28333f'
+    table_subtitle_family: IBM Plex Sans
+    table_subtitle_size: 18
+    table_subtitle_weight: normal
+    table_caption_color: '#28333f'
+    table_caption_family: IBM Plex Sans
+    table_caption_size: 11
+    table_caption_weight: normal
+    header_text_color: "#ffffff"
+    header_text_family: Fjalla One
+    header_text_size: 22
+    header_text_weight: 700
+    cell_text_color: '#28333f'
+    cell_text_family: IBM Plex Sans
+    cell_text_size: 18
+    cell_text_weight: 400
+    link_color: "#e59fd7"
+    header_background: "#385573"
+    zebra_stripe_color: "#f6fcfa"
+    desactivated_controls: "#bbbdc0"
 palettes:
   light:
     main:

--- a/inst/themes/public.yaml
+++ b/inst/themes/public.yaml
@@ -56,6 +56,7 @@ themes:
     link_color: "#287e68"
     header_background: "#385573"
     table_background: "#ffffff"
+    table_border_color: "#BBBDC0"
     zebra_stripe_color: "#fafafa"
     desactivated_controls: "#becacc"
   dark:
@@ -113,6 +114,7 @@ themes:
     link_color: "#99e8b3"
     header_background: "#385573"
     table_background: "#222526"
+    table_border_color: "#73777D"
     zebra_stripe_color: "#2b3238"
     desactivated_controls: "#73777d"
 palettes:

--- a/inst/themes/public.yaml
+++ b/inst/themes/public.yaml
@@ -36,7 +36,7 @@ themes:
     table_title_color: '#28333f'
     table_title_family: IBM Plex Sans
     table_title_size: 30
-    table_title_weight: normal
+    table_title_weight: bold
     table_subtitle_color: '#28333f'
     table_subtitle_family: IBM Plex Sans
     table_subtitle_size: 18
@@ -47,16 +47,16 @@ themes:
     table_caption_weight: normal
     header_text_color: "#ffffff"
     header_text_family: IBM Plex Sans
-    header_text_size: 22
-    header_text_weight: 700
+    header_text_size: 21
+    header_text_weight: bold
     cell_text_color: '#28333f'
     cell_text_family: IBM Plex Sans
     cell_text_size: 18
-    cell_text_weight: 400
-    link_color: "#e59fd7"
+    cell_text_weight: normal
+    link_color: "#287e68"
     header_background: "#385573"
-    zebra_stripe_color: "#f6fcfa"
-    desactivated_controls: "#bbbdc0"
+    zebra_stripe_color: "#fafafa"
+    desactivated_controls: "#becacc"
   dark:
     logo: datasketch
     logo_position: right
@@ -89,30 +89,30 @@ themes:
     legend_family: IBM Plex Sans
     grid_color: '#a1a0a5'
     grid_line_type: Dot
-    table_title_color: '#28333f'
+    table_title_color: '#ffffff'
     table_title_family: IBM Plex Sans
     table_title_size: 30
-    table_title_weight: normal
-    table_subtitle_color: '#28333f'
+    table_title_weight: bold
+    table_subtitle_color: '#ffffff'
     table_subtitle_family: IBM Plex Sans
     table_subtitle_size: 18
     table_subtitle_weight: normal
-    table_caption_color: '#28333f'
+    table_caption_color: '#ffffff'
     table_caption_family: IBM Plex Sans
     table_caption_size: 11
     table_caption_weight: normal
     header_text_color: "#ffffff"
     header_text_family: IBM Plex Sans
-    header_text_size: 22
-    header_text_weight: 700
-    cell_text_color: '#28333f'
+    header_text_size: 21
+    header_text_weight: bold
+    cell_text_color: '#ffffff'
     cell_text_family: IBM Plex Sans
     cell_text_size: 18
-    cell_text_weight: 400
-    link_color: "#e59fd7"
+    cell_text_weight: normal
+    link_color: "#99e8b3"
     header_background: "#385573"
-    zebra_stripe_color: "#f6fcfa"
-    desactivated_controls: "#bbbdc0"
+    zebra_stripe_color: "#2b3238"
+    desactivated_controls: "#73777d"
 palettes:
   light:
     main:

--- a/inst/themes/public.yaml
+++ b/inst/themes/public.yaml
@@ -46,7 +46,7 @@ themes:
     table_caption_size: 11
     table_caption_weight: normal
     header_text_color: "#ffffff"
-    header_text_family: Fjalla One
+    header_text_family: IBM Plex Sans
     header_text_size: 22
     header_text_weight: 700
     cell_text_color: '#28333f'


### PR DESCRIPTION
Adding table styling options:
- font styling: size, weight, color of table title, subtitle, header text, cell text, and caption text, as well as link text color
- header background color
- table background color
- table border color
- zebra stripe color
- color for deactivated controls

NOTE: Only the `public` and `ojo-con-mi-pisto` themes have fully designed table themes. The others have been adapted based on the `public` theme, using the organisation's font type and the first colors of their palettes.